### PR TITLE
Fix leaking interval handles

### DIFF
--- a/src/cloud.js
+++ b/src/cloud.js
@@ -46,7 +46,7 @@ addEventListener('fetch', event => {
 		dbo = new User("dbo",{"#":"User@dbo",roles:{dbo:true}});
 	request.URL = new URL(request.url);
 	thunderhead = new Thunderhead({request,namespace:NAMESPACE,dbo});
-	setInterval(() => {
+	setTimeout(() => {
 		thunderhead.resetCache();
 	},5000)
 	event.respondWith(handleRequest(event));


### PR DESCRIPTION
This looks like an awesome project!

I was just reading through the code and I noticed this `setInterval` call and figured you _probably_ meant `setTimeout`. Creating new interval tickers on each request is probably bad :)